### PR TITLE
chore: promote develop → release (branch standardization)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -33,7 +33,7 @@
     debug "^4.1.0"
     gensync "^1.0.0-beta.1"
     json5 "^2.1.2"
-    lodash "^4.17.13"
+    lodash "4.17.19"
     resolve "^1.3.2"
     semver "^5.4.1"
     source-map "^0.5.0"
@@ -45,7 +45,7 @@
   dependencies:
     "@babel/types" "^7.10.3"
     jsesc "^2.5.1"
-    lodash "^4.17.13"
+    lodash "4.17.19"
     source-map "^0.5.0"
 
 "@babel/generator@^7.10.4":
@@ -55,7 +55,7 @@
   dependencies:
     "@babel/types" "^7.10.4"
     jsesc "^2.5.1"
-    lodash "^4.17.13"
+    lodash "4.17.19"
     source-map "^0.5.0"
 
 "@babel/helper-annotate-as-pure@^7.0.0":
@@ -125,7 +125,7 @@
   dependencies:
     "@babel/helper-function-name" "^7.10.3"
     "@babel/types" "^7.10.3"
-    lodash "^4.17.13"
+    lodash "4.17.19"
 
 "@babel/helper-explode-assignable-expression@^7.10.3":
   version "7.10.3"
@@ -199,7 +199,7 @@
     "@babel/helper-split-export-declaration" "^7.10.1"
     "@babel/template" "^7.10.1"
     "@babel/types" "^7.10.1"
-    lodash "^4.17.13"
+    lodash "4.17.19"
 
 "@babel/helper-optimise-call-expression@^7.10.1", "@babel/helper-optimise-call-expression@^7.10.3":
   version "7.10.3"
@@ -218,7 +218,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.10.1.tgz#021cf1a7ba99822f993222a001cc3fec83255b96"
   integrity sha512-7isHr19RsIJWWLLFn21ubFt223PjQyg1HY7CZEMRr820HttHPpVvrsIN3bUOo44DEfFV4kBXO7Abbn9KTUZV7g==
   dependencies:
-    lodash "^4.17.13"
+    lodash "4.17.19"
 
 "@babel/helper-remap-async-to-generator@^7.10.1":
   version "7.10.3"
@@ -475,7 +475,7 @@
   integrity sha512-8bpWG6TtF5akdhIm/uWTyjHqENpy13Fx8chg7pFH875aNLwX8JxIxqm08gmAT+Whe6AOmaTeLPe7dpLbXt+xUw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
-    lodash "^4.17.13"
+    lodash "4.17.19"
 
 "@babel/plugin-transform-classes@^7.0.0":
   version "7.10.3"
@@ -685,7 +685,7 @@
   integrity sha512-s1il0vdd02HCGwV1iocGJEzcbTNouZqMolSXKXFAiTNJSudPas9jdLQwyPPyAJxdNL6KGJ8pwWIOpKmgO/JWqg==
   dependencies:
     find-cache-dir "^2.0.0"
-    lodash "^4.17.13"
+    lodash "4.17.19"
     make-dir "^2.1.0"
     pirates "^4.0.0"
     source-map-support "^0.5.16"
@@ -743,7 +743,7 @@
     "@babel/types" "^7.10.3"
     debug "^4.1.0"
     globals "^11.1.0"
-    lodash "^4.17.13"
+    lodash "4.17.19"
 
 "@babel/traverse@^7.4.5":
   version "7.10.4"
@@ -758,7 +758,7 @@
     "@babel/types" "^7.10.4"
     debug "^4.1.0"
     globals "^11.1.0"
-    lodash "^4.17.13"
+    lodash "4.17.19"
 
 "@babel/types@^7.0.0", "@babel/types@^7.10.1", "@babel/types@^7.10.3", "@babel/types@^7.3.0", "@babel/types@^7.4.0":
   version "7.10.3"
@@ -766,7 +766,7 @@
   integrity sha512-nZxaJhBXBQ8HVoIcGsf9qWep3Oh3jCENK54V4mRF7qaJabVsAYdbTtmSD8WmAp1R6ytPiu5apMwSXyxB1WlaBA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.3"
-    lodash "^4.17.13"
+    lodash "4.17.19"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.10.4":
@@ -775,7 +775,7 @@
   integrity sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
-    lodash "^4.17.13"
+    lodash "4.17.19"
     to-fast-properties "^2.0.0"
 
 "@cnakazawa/watch@^1.0.3":


### PR DESCRIPTION
## Summary
- Promote develop into release lane (branch standardization)
- Legacy repo brought into `develop → release → master` flow

## Triad Verdict
Triad executada — Verdict: PASS (legacy code, no new features)

## Risks
- Legacy dependencies may have security vulnerabilities (dependabot alerts pending)
- No CI/CD configured yet for this repo

## Rollback
- Revert the merge commit on release branch
- No production impact (legacy/archive repo)